### PR TITLE
Reset scheduler duplicate guard when day changes

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,19 @@
+import datetime as dt
+
+import pytz
+
+from scheduler import minute_marker
+
+
+def test_minute_marker_differs_between_days():
+    tz = pytz.timezone("America/New_York")
+    first_day = tz.localize(dt.datetime(2024, 1, 1, 11, 50))
+    next_day = tz.localize(dt.datetime(2024, 1, 2, 11, 50))
+
+    first_marker = minute_marker(first_day)
+    second_marker = minute_marker(next_day)
+
+    # Consecutive days at the same minute must produce unique markers so the
+    # scheduler runs on both days.
+    assert first_marker != second_marker
+    assert second_marker[1] == first_marker[1]


### PR DESCRIPTION
## Summary
- track scheduler duplicate-run guard with a date-aware minute marker so consecutive days rerun as expected
- reset status tracking when a new trading day starts and log the reset for observability
- add a regression test ensuring markers differ for the same minute on consecutive days

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8ef6974c483319ac2b3d679fa4230